### PR TITLE
Fix Two Order-Dependent Flaky Tests

### DIFF
--- a/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
+++ b/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
@@ -69,16 +69,26 @@ public abstract class CachedStreamTestBase {
 
     @Test
     public void testDeleteTmpFile() throws IOException {
-        Object cache = createCache();
-        //ensure output data size larger then 64k which will generate tmp file
-        String result = initTestData(65);
-        File tempFile = getTmpFile(result, cache);
-        assertNotNull(tempFile);
-        //assert tmp file is generated
-        assertTrue(tempFile.exists());
-        close(cache);
-        //assert tmp file is deleted after close the CachedOutputStream
-        assertFalse(tempFile.exists());
+        String old = System.getProperty(CachedConstants.THRESHOLD_SYS_PROP);
+        try {
+            System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, "4");
+            reloadDefaultProperties();
+            Object cache = createCache();
+            //ensure output data size larger then 64k which will generate tmp file
+            String result = initTestData(65);
+            File tempFile = getTmpFile(result, cache);
+            assertNotNull(tempFile);
+            //assert tmp file is generated
+            assertTrue(tempFile.exists());
+            close(cache);
+            //assert tmp file is deleted after close the CachedOutputStream
+            assertFalse(tempFile.exists());
+        } finally {
+            System.clearProperty(CachedConstants.THRESHOLD_SYS_PROP);
+            if (old != null) {
+                System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, old);
+            }
+        }
     }
 
     @Test

--- a/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
+++ b/core/src/test/java/org/apache/cxf/io/CachedStreamTestBase.java
@@ -88,6 +88,7 @@ public abstract class CachedStreamTestBase {
             if (old != null) {
                 System.setProperty(CachedConstants.THRESHOLD_SYS_PROP, old);
             }
+            reloadDefaultProperties();
         }
     }
 


### PR DESCRIPTION
**Issue**
The tests `org.apache.cxf.io.CacheAndWriteOutputStreamTest.testDeleteTmpFile` and `org.apache.cxf.io.CachedOutputStreamTest.testDeleteTmpFile` fail when run by themselves with the command `mvn test` because the temporary file is null. The reason is because  `createFileOutPutStream` is never called in the method `enforceLimits` in the `CachedOutputStream` class since the `threshold` instance variable is not greater than the `totalLength` variable. The threshold variable depends on the static variable `defaultThreshold`. Therefore, these tests pass when the whole test suite is run because a different test, such as `testUseSysProps` changes the static variable. 

**Solution**
In order to allow these two tests to pass on their own, the system property must first be set to 4. Next, the static variables need to be updated with a call to `reloadDefaultProperties`. Since the previous versions of these tests do not change system properties, the test should then reset the system property to the original state once finished executing.

